### PR TITLE
fix: bumped version

### DIFF
--- a/charts/roclub-conference2/values.yaml
+++ b/charts/roclub-conference2/values.yaml
@@ -23,7 +23,7 @@ frontend:
   image:
     repository: ghcr.io/roclub/livekit-remote-control-conference-development
     pullPolicy: IfNotPresent
-    tag: "0.1.9"
+    tag: "0.1.13"
     
   replicaCount: 1
 


### PR DESCRIPTION
bumped version to 0.1.13

closes: https://github.com/roclub/livekit-remote-control-conference/issues/17