### PR TITLE
fix: bumped conf2 version 0.1.15

### DIFF
--- a/charts/roclub-conference2/Chart.yaml
+++ b/charts/roclub-conference2/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: roclub-conference2
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.1.14
-appVersion: 0.1.14
+version: 0.1.15
+appVersion: 0.1.15


### PR DESCRIPTION
bumped conference2 version to 0.1.15

closes: https://github.com/roclub/livekit-remote-control-conference/issues/31