### PR TITLE
chore: bumped conf2 version

### DIFF
--- a/charts/roclub-conference2/Chart.yaml
+++ b/charts/roclub-conference2/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: roclub-conference2
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.1.15
-appVersion: 0.1.15
+version: 0.2.0
+appVersion: 0.2.0


### PR DESCRIPTION
bumped conf2 version

closes: https://github.com/roclub/livekit-remote-control-conference/issues/33