### PR TITLE
feat: add probes for controlplane

### DIFF
--- a/charts/controlplane/templates/connector-control/deployment.yaml
+++ b/charts/controlplane/templates/connector-control/deployment.yaml
@@ -43,6 +43,24 @@ spec:
             - name: http
               containerPort: {{ .Values.connectorControl.service.httpPort }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: v1/health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: v1/health
+              port: http
+            failureThreshold: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: v1/ready
+              port: http
+            failureThreshold: 2
+            periodSeconds: 30
           resources:
             {{- toYaml .Values.connectorControl.resources | nindent 12 }}
           volumeMounts:

--- a/charts/controlplane/templates/connector-status/deployment.yaml
+++ b/charts/controlplane/templates/connector-status/deployment.yaml
@@ -40,6 +40,24 @@ spec:
             - name: http
               containerPort: {{ .Values.connectorStatus.service.httpPort }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: v1/health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: v1/health
+              port: http
+            failureThreshold: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: v1/ready
+              port: http
+            failureThreshold: 2
+            periodSeconds: 30
           resources:
             {{- toYaml .Values.connectorStatus.resources | nindent 12 }}
           volumeMounts:

--- a/charts/controlplane/templates/remote-control/deployment.yaml
+++ b/charts/controlplane/templates/remote-control/deployment.yaml
@@ -40,6 +40,24 @@ spec:
             - name: http
               containerPort: {{ .Values.remoteControl.service.httpPort }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: v1/health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: v1/health
+              port: http
+            failureThreshold: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: v1/ready
+              port: http
+            failureThreshold: 2
+            periodSeconds: 30
           resources:
             {{- toYaml .Values.remoteControl.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Uses the exposed /health and /ready endpoints from the controlplane services to add startup, liveness and readiness probes for all 3 controlplane services.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> Closes #81 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->