### PR TITLE
chore: bumped conf2 0.2.2

### DIFF
--- a/charts/roclub-conference2/Chart.yaml
+++ b/charts/roclub-conference2/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: roclub-conference2
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.2.1
-appVersion: 0.2.1
+version: 0.2.2
+appVersion: 0.2.2


### PR DESCRIPTION
bumped conf2 version to 0.2.2

closes: https://github.com/roclub/livekit-remote-control-conference/issues/56