### PR TITLE
fix: Knowledgebase traffic

### DIFF
--- a/charts/knowledgebase/Chart.yaml
+++ b/charts/knowledgebase/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: knowledgebase
 description: Deploys the roclub knowledgebase stack to Kubernetes
-version: 0.3.1
-appVersion: "0.3.1"
+version: 0.3.2
+appVersion: "0.3.2"

--- a/charts/knowledgebase/templates/envoy-gateway/gateway.yaml
+++ b/charts/knowledgebase/templates/envoy-gateway/gateway.yaml
@@ -10,12 +10,12 @@ spec:
     type: Kubernetes
     kubernetes:
       envoyService:
-        externalTrafficPolicy: Cluster
         annotations:
           service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: kubernetes.io/service-name={{ $fullname }}-knowledgebase
           service.beta.kubernetes.io/aws-load-balancer-name: {{ $fullname }}-knowledgebase
           service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
           service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+          service.beta.kubernetes.io/aws-load-balancer-type: external
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass


### PR DESCRIPTION
- **Added NLB type to reduce latency**
- **Bumped Chart Version**
closes: #94 