### PR TITLE
chore: bump conference to 0.7.18

### DIFF
--- a/charts/roclub-conference/Chart.yaml
+++ b/charts/roclub-conference/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conference
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.6.1
-appVersion: 0.7.15
+version: 0.6.2
+appVersion: 0.7.18


### PR DESCRIPTION
closes: https://github.com/roclub/helm-charts/issues/154