### PR TITLE
fix: give readiness probes more timeout

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.11.3
+version: 2.11.2
 appVersion: "2.9.2"
 dependencies:
 - name: influxdb2

--- a/charts/controlplane/templates/authz/deployment.yaml
+++ b/charts/controlplane/templates/authz/deployment.yaml
@@ -48,18 +48,21 @@ spec:
               path: v1/health
               port: http
             failureThreshold: 30
+            timeoutSeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: v1/health
               port: http
             failureThreshold: 3
+            timeoutSeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: v1/ready
               port: http
             failureThreshold: 2
+            timeoutSeconds: 10
             periodSeconds: 30
           resources:
             {{- toYaml .Values.authZ.resources | nindent 12 }}

--- a/charts/controlplane/templates/connector-control/deployment.yaml
+++ b/charts/controlplane/templates/connector-control/deployment.yaml
@@ -48,18 +48,21 @@ spec:
               path: v1/health
               port: http
             failureThreshold: 30
+            timeoutSeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: v1/health
               port: http
             failureThreshold: 3
+            timeoutSeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: v1/ready
               port: http
             failureThreshold: 2
+            timeoutSeconds: 10
             periodSeconds: 30
           resources:
             {{- toYaml .Values.connectorControl.resources | nindent 12 }}

--- a/charts/controlplane/templates/connector-status/deployment.yaml
+++ b/charts/controlplane/templates/connector-status/deployment.yaml
@@ -45,18 +45,21 @@ spec:
               path: v1/health
               port: http
             failureThreshold: 30
+            timeoutSeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: v1/health
               port: http
             failureThreshold: 3
+            timeoutSeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: v1/ready
               port: http
             failureThreshold: 2
+            timeoutSeconds: 10
             periodSeconds: 30
           resources:
             {{- toYaml .Values.connectorStatus.resources | nindent 12 }}

--- a/charts/controlplane/templates/notifications/deployment.yaml
+++ b/charts/controlplane/templates/notifications/deployment.yaml
@@ -45,18 +45,21 @@ spec:
               path: v1/health
               port: http
             failureThreshold: 30
+            timeoutSeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: v1/health
               port: http
             failureThreshold: 3
+            timeoutSeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: v1/ready
               port: http
             failureThreshold: 2
+            timeoutSeconds: 10
             periodSeconds: 30
           resources:
             {{- toYaml .Values.notifications.resources | nindent 12 }}

--- a/charts/controlplane/templates/remote-control/deployment.yaml
+++ b/charts/controlplane/templates/remote-control/deployment.yaml
@@ -45,18 +45,21 @@ spec:
               path: v1/health
               port: http
             failureThreshold: 30
+            timeoutSeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: v1/health
               port: http
             failureThreshold: 3
+            timeoutSeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: v1/ready
               port: http
             failureThreshold: 2
+            timeoutSeconds: 10
             periodSeconds: 30
           resources:
             {{- toYaml .Values.remoteControl.resources | nindent 12 }}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Add timeout for all health probes to 5s
- Add timeout for all readiness probes to 10s

This should be plenty of time (also for the future) to make all checks.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> Closes #222 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->