### PR TITLE
fix: add jwks cache and async fetch for better performance

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.15.15
+version: 2.15.16
 appVersion: "2.12.11"
 dependencies:
 - name: influxdb2

--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.15.16
+version: 2.15.17
 appVersion: "2.12.11"
 dependencies:
 - name: influxdb2

--- a/charts/controlplane/templates/envoy_patch_policy.yaml
+++ b/charts/controlplane/templates/envoy_patch_policy.yaml
@@ -1,0 +1,24 @@
+{{- $gatewayName := include "controlplane.fullname" . -}}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyPatchPolicy
+metadata:
+  name: {{ $gatewayName }}-jwks-cache-patch
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ $gatewayName }}
+  type: JSONPatch
+  jsonPatches:
+  - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
+    name: "jwt-authn-patch"
+    operation:
+      op: replace
+      path: "/filter_chains/0/filters/0/typed_config/providers/zitadel/remote_jwks/async_fetch"
+      value: true
+  - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
+    name: "jwt-cache-patch"
+    operation:
+      op: replace
+      path: "/filter_chains/0/filters/0/typed_config/providers/zitadel/remote_jwks/cache_duration"
+      value: "5s"

--- a/charts/controlplane/templates/security_policy.yaml
+++ b/charts/controlplane/templates/security_policy.yaml
@@ -21,8 +21,6 @@ spec:
         backendSettings:
           retry:
             numRetries: 5
-            retryPolicy:
-              timeout: 2
   cors:
     allowOrigins:
     - "https://conference.{{ .Values.stage }}.roclub.io"


### PR DESCRIPTION
hey gova,

this pr add jwks caching and async fetch to make our auth faster.

## Summary
- add EnvoyPatchPolicy to patch jwks config with async_fetch=true and cache_duration=5s  
- target our specific gateway so only our routes get this patch
- this make auth requests not block and cache keys for better performance

## Test plan
- deploy to staging and check auth still work
- check envoy logs that jwks fetch is async 
- verify performance is better with cached keys

fixes: #348
