### PR TITLE
chore: bump controlplane version to 2.12.15

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.15.20
-appVersion: "2.12.14"
+version: 2.15.21
+appVersion: "2.12.15"
 dependencies:
 - name: influxdb2
   version: 2.1.2


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Automatically releases https://github.com/roclub/controlplane/releases/tag/2.12.15 to Dev & Stg

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> Closes #121 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->