### PR TITLE
feat: Update image repository and remove imagePullSecrets

### DIFF
--- a/charts/knowledgebase/values.yaml
+++ b/charts/knowledgebase/values.yaml
@@ -1,12 +1,12 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/roclub/knowledgebase
+  repository: habor.mgt.roclub.io/roclub/roclub/knowledgbase
   pullPolicy: IfNotPresent
   tag: ""
 
-imagePullSecrets:
-- name: dockerconfigjson-github-com
+imagePullSecrets: []
+
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Description
Updated the image repository path, to point to the Harbor image, removed the ImagePullSecret, because it has been defined in the knowledbase.yaml in app-controlplane. 

## Related Issue
https://github.com/roclub/gitops/issues/567

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->