### PR TITLE
chore: Bump version to 1.6.1 in Chart.yaml

### DIFF
--- a/charts/knowledgebase/Chart.yaml
+++ b/charts/knowledgebase/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: knowledgebase
 description: Deploys the roclub knowledgebase stack to Kubernetes
-version: 1.6.0
+version: 1.6.1
 appVersion: "1.5.1"


### PR DESCRIPTION
## Description
See https://github.com/roclub/knowledgebase/releases/tag/1.5.1

## Related Issue
See https://github.com/roclub/knowledgebase/releases/tag/1.5.1

## Motivation and Context
https://github.com/roclub/knowledgebase/releases/tag/1.5.1

## How Has This Been Tested?
https://github.com/roclub/knowledgebase/releases/tag/1.5.1