### PR TITLE
feat: add authZ.enabled flag and bump chart version

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.17.4
+version: 2.17.5
 appVersion: "2.14.4"
 dependencies:
 - name: influxdb2

--- a/charts/controlplane/templates/authz/config.yaml
+++ b/charts/controlplane/templates/authz/config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.authZ.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,3 +18,4 @@ data:
 
     [authz.logger]
     level = "{{ .Values.authZ.config.logger }}"
+{{- end }}

--- a/charts/controlplane/templates/authz/deployment.yaml
+++ b/charts/controlplane/templates/authz/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.authZ.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -85,3 +86,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/controlplane/templates/authz/hpa.yaml
+++ b/charts/controlplane/templates/authz/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.authZ.autoscaling.enabled }}
+{{- if and .Values.authZ.enabled .Values.authZ.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/controlplane/templates/authz/route.yaml
+++ b/charts/controlplane/templates/authz/route.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.authZ.enabled }}
 {{- $gatewayName := include "controlplane.fullname" . -}}
 {{- $name := include "controlplane.authZName" . -}}
 {{- $svcPort := .Values.authZ.service.httpPort -}}
@@ -50,4 +51,4 @@ spec:
         - name: {{ $name }}
           port: {{ $svcPort }}
   {{- end }}
-
+{{- end }}

--- a/charts/controlplane/templates/authz/service.yaml
+++ b/charts/controlplane/templates/authz/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.authZ.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
       name: http
   selector:
     {{- include "controlplane.selectorLabelsAuthZ" . | nindent 4 }}
+{{- end }}

--- a/charts/controlplane/templates/authz/service_account.yaml
+++ b/charts/controlplane/templates/authz/service_account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.authZ.serviceAccount.create -}}
+{{- if and .Values.authZ.enabled .Values.authZ.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -285,6 +285,8 @@ connectorControl:
   tolerations: []
 
 authZ:
+  enabled: true
+
   image:
     repository: ghcr.io/roclub/controlplane-authz
     pullPolicy: Always


### PR DESCRIPTION
## Description
Add authZ.enabled to the controlplane chart and defaults it to true so existing behavior remains unchanged.

Changes:
- Add authZ.enabled to chart values
- Wrap legacy AuthZ manifests behind the new flag
- Bump controlplane chart version to 2.17.5

## Related Issue
https://github.com/roclub/helm-charts/issues/441

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->