### PR TITLE
feat: adds disabled config redis for controlplane

### DIFF
--- a/charts/controlplane/templates/connector-control/config.yaml
+++ b/charts/controlplane/templates/connector-control/config.yaml
@@ -14,6 +14,17 @@ data:
     key    = "{{ .Values.connectorControl.config.iotDataplane.key }}"
     secret = "{{ .Values.connectorControl.config.iotDataplane.secret }}"
 
+    [connector_control.redis]
+    enabled = {{ .Values.connectorControl.config.redis.enabled }}
+    url = "{{ .Values.connectorControl.config.redis.url }}"
+    username = "{{ .Values.connectorControl.config.redis.username }}"
+    password = "{{ .Values.connectorControl.config.redis.password }}"
+    db = {{ .Values.connectorControl.config.redis.db }}
+    ttl_seconds = {{ .Values.connectorControl.config.redis.ttlSeconds }}
+    negative_ttl_seconds = {{ .Values.connectorControl.config.redis.negativeTtlSeconds }}
+    timeout_ms = {{ .Values.connectorControl.config.redis.timeoutMs }}
+    max_retries = {{ .Values.connectorControl.config.redis.maxRetries }}
+
     [connector_control.authz_service]
     address = "http://{{ .Values.authZ.service.name}}:8080"
 

--- a/charts/controlplane/templates/remote-control/config.yaml
+++ b/charts/controlplane/templates/remote-control/config.yaml
@@ -14,6 +14,17 @@ data:
     key    = "{{ .Values.remoteControl.config.iotDataplane.key }}"
     secret = "{{ .Values.remoteControl.config.iotDataplane.secret }}"
 
+    [session_control.redis]
+    enabled = {{ .Values.remoteControl.config.redis.enabled }}
+    url = "{{ .Values.remoteControl.config.redis.url }}"
+    username = "{{ .Values.remoteControl.config.redis.username }}"
+    password = "{{ .Values.remoteControl.config.redis.password }}"
+    db = {{ .Values.remoteControl.config.redis.db }}
+    ttl_seconds = {{ .Values.remoteControl.config.redis.ttlSeconds }}
+    negative_ttl_seconds = {{ .Values.remoteControl.config.redis.negativeTtlSeconds }}
+    timeout_ms = {{ .Values.remoteControl.config.redis.timeoutMs }}
+    max_retries = {{ .Values.remoteControl.config.redis.maxRetries }}
+
     [session_control.liveKit]
     key = "{{ .Values.remoteControl.config.liveKit.key }}"
     secret = "{{ .Values.remoteControl.config.liveKit.secret }}"

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -73,6 +73,17 @@ remoteControl:
       key: ""
       secret: ""
 
+    redis:
+      enabled: false
+      url: ""
+      username: ""
+      password: ""
+      db: 0
+      ttlSeconds: 300
+      negativeTtlSeconds: 10
+      timeoutMs: 2000
+      maxRetries: 3
+
     liveKit:
       key: ""
       secret: ""
@@ -247,6 +258,17 @@ connectorControl:
     iotDataplane:
       key: ""
       secret: ""
+
+    redis:
+      enabled: false
+      url: ""
+      username: ""
+      password: ""
+      db: 0
+      ttlSeconds: 300
+      negativeTtlSeconds: 10
+      timeoutMs: 2000
+      maxRetries: 3
 
     logger: "debug"
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds a distributed caching layer (Redis) for AWS IoT “thing” existence checks in the control plane, reducing repeated AWS IoT API calls and mitigating throttling exceptions.

## Related Issue
Step 2 of https://github.com/roclub/controlplane/issues/478
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is needed because in the last 30 days we got some throttling exceptions from AWS IoT API. This is because we do too many calls, for every operation we first check if the device exists.

We mitigated the problem changing the type of check in https://github.com/roclub/controlplane/pull/477 but this cache further mitigates it.

## How Has This Been Tested?
Tested locally using Redis via Docker Compose. Verified that cache hits prevent additional calls to the AWS IoT API. Configured TTL works both on positive or negative existence check.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->