### PR TITLE
fix: Changed HTTP01 resolver to DNS01 resolver for Let's Encrypt challenge

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: app
 description: Deploys the roclub main application to Kubernetes
 type: application
-version: 0.15.1
+version: 0.15.2
 appVersion: 0.14.0
 
 dependencies:

--- a/charts/app/templates/gateway.yaml
+++ b/charts/app/templates/gateway.yaml
@@ -69,9 +69,8 @@ spec:
     privateKeySecretRef:
       name: {{ $fullName }}-letsencrypt
     solvers:
-    - http01:
-        gatewayHTTPRoute:
-          parentRefs:
-          - kind: Gateway
-            name: {{ $fullName }}
+    - dns01:
+        route53:
+          region: eu-central-1
+          hostedZoneID: {{ .Values.cloudfront.hostedZoneID }}
 {{- end -}}


### PR DESCRIPTION
With the move over to CloudFront CDN we enforce traffic to 443 before it even reaches the NLB.
The HTTP challenge uses HTTP to GET the text behind challenge. With bumping protocols at CDN Level the NLB tries to route the traffic to HTTPS in Order Pod which does not exist (certificate not provisioned yet).

#466