### PR TITLE
fix: Controlplane read InfluxDB2 Token dynamically

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.23.0
+version: 2.23.1
 appVersion: "2.18.0"
 dependencies:
 - name: influxdb2

--- a/charts/controlplane/templates/connector-status/deployment.yaml
+++ b/charts/controlplane/templates/connector-status/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $name := printf "%s-auth" "influxdb2" }}
+{{- $influxToken := lookup "v1" "Secret" .Release.Namespace $name }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -68,10 +70,7 @@ spec:
             mountPath: /etc/edged/
           env:
           - name: INFLUXDB_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "controlplane.fullname" . }}-influxdb2-auth 
-                key: admin-token
+            value: {{ index $influxToken.data "admin-token" }}
       volumes:
         - name: config-volume
           configMap:

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -156,7 +156,6 @@ connectorStatus:
 
     influx:
       org: "roclub"
-      token: ""
 
     logger: "debug"
 


### PR DESCRIPTION
There is currently an issue with specifying token beforehand.