### PR TITLE
fix: Controlplane InfluxDB2 Token Rendering during Helm Template

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.23.1
+version: 2.23.2
 appVersion: "2.18.0"
 dependencies:
 - name: influxdb2

--- a/charts/controlplane/templates/connector-status/deployment.yaml
+++ b/charts/controlplane/templates/connector-status/deployment.yaml
@@ -1,5 +1,3 @@
-{{- $name := printf "%s-auth" "influxdb2" }}
-{{- $influxToken := lookup "v1" "Secret" .Release.Namespace $name }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -70,7 +68,10 @@ spec:
             mountPath: /etc/edged/
           env:
           - name: INFLUXDB_TOKEN
-            value: {{ index $influxToken.data "admin-token" }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "controlplane.fullname" . }}-influxdb2-auth
+                key: admin-token
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
ArgoCD uses  `Helm Template` for apply, so lookup on first installation does not work, only on upgrade
