### PR TITLE
chore: bump conference chart to 0.27.7 new livekit client

### DIFF
--- a/charts/roclub-conference/Chart.yaml
+++ b/charts/roclub-conference/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conference
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.27.6
-appVersion: 0.27.6
+version: 0.27.7
+appVersion: 0.27.7


### PR DESCRIPTION
## Description
Bumps the `roclub-conference` chart `version` and `appVersion` from `0.27.6` to `0.27.7`. Only `charts/roclub-conference/Chart.yaml` changes, no template or values changes.

## Related Issue
N/A. Routine version bump (`chore`), exempt from the linked-issue requirement. Context lives in the app PR: roclub/livekit-remote-control#726

## Motivation and Context
Deploys the new conference app release `0.27.7`, which ships the `livekit-client` single peer connection upgrade. With it, a single participant opens 1 `RTCPeerConnection` instead of 2 (legacy publisher plus subscriber split). This chart bump is what rolls that release out to the cluster.

## How Has This Been Tested?
helm lint / helm template render cleanly; only the image tag changes.