### PR TITLE
fix: allow requestid envoy policy

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.25.0
+version: 2.25.1
 appVersion: "2.19.1"
 dependencies:
 - name: influxdb2

--- a/charts/controlplane/templates/security_policy.yaml
+++ b/charts/controlplane/templates/security_policy.yaml
@@ -43,6 +43,7 @@ spec:
     - "Content-Type"
     - "Accept"
     - "Content-Length"
+    - "X-Request-ID"
     exposeHeaders:
     - "Content-Length"
     # Our App will be only used by Chromium Browsers, Chromiums default value is 7200, we adapt to that.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Allows Request ID in CORS Envoy

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/roclub/controlplane/issues/489

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

If frontend wants to send X-Request-ID to our controlplane, we want to allow that header in both controlplane and our gateway, Envoy

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->