### PR TITLE
chore: bump conference chart to 0.27.9 new hubspot urls

### DIFF
--- a/charts/roclub-conference/Chart.yaml
+++ b/charts/roclub-conference/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conference
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.27.7
-appVersion: 0.27.7
+version: 0.27.9
+appVersion: 0.27.9


### PR DESCRIPTION
## Description

  Bumps `roclub-conference` chart from `0.27.7` to `0.27.9` to deploy the updated HubSpot support form URLs.

  The app change ([#730](https://github.com/roclub/livekit-remote-control/pull/730)) updated the HubSpot ticket URLs for both `de` and `en` locales in `src/common/constants.ts` so they now point to the correct new form.

  **Changes:**
  - `charts/roclub-conference/Chart.yaml`: `version` and `appVersion` bumped to `0.27.9`

## How Has This Been Tested?

helm lint / helm template render cleanly; only the image tag changes.