### PR TITLE
chore: allow client request id in envoy

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.25.1
+version: 2.25.2
 appVersion: "2.19.1"
 dependencies:
 - name: influxdb2

--- a/charts/controlplane/templates/envoy_patch_policy.yaml
+++ b/charts/controlplane/templates/envoy_patch_policy.yaml
@@ -22,3 +22,15 @@ spec:
       op: replace
       path: "/filter_chains/0/filters/0/typed_config/providers/zitadel/remote_jwks/cache_duration"
       value: "5s"
+  - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
+    name: "preserve-external-request-id-patch"
+    operation:
+      op: add
+      path: "/filter_chains/0/filters/0/typed_config/preserve_external_request_id"
+      value: true
+  - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
+    name: "use-remote-address-patch"
+    operation:
+      op: add
+      path: "/filter_chains/0/filters/0/typed_config/use_remote_address"
+      value: true


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Make envoy accept headers X-Request-ID

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/roclub/controlplane/issues/489

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Right now Envoy is ignoring that header, but we want to accept it to be able to trace the whole request from frontend to backend

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->