### PR TITLE
docs: adapted version of KB to 1.5.2

### DIFF
--- a/charts/knowledgebase/Chart.yaml
+++ b/charts/knowledgebase/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: knowledgebase
 description: Deploys the roclub knowledgebase stack to Kubernetes
-version: 1.7.1
-appVersion: "1.5.1"
+version: 1.7.2
+appVersion: "1.5.2"


### PR DESCRIPTION
KB Release to bring PR #201 https://github.com/roclub/knowledgebase/pull/201 live

## Description
Adapted Version Tag for Knowledgebase release to 1.5.2

## Related Issue
n.a.

## Motivation and Context
fixing image links for DisplayApp articles

## How Has This Been Tested?
no possibility for testing, the instructions in the readme files were followed