### PR TITLE
feat: preserve request id envoy patch policy

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.26.0
+version: 2.27.0
 appVersion: "2.20.0"
 dependencies:
 - name: influxdb2

--- a/charts/controlplane/templates/envoy_patch_policy_request_id.yaml
+++ b/charts/controlplane/templates/envoy_patch_policy_request_id.yaml
@@ -14,7 +14,19 @@ spec:
     name: "{{ .Release.Namespace }}/{{ $gatewayName }}/http"
     operation:
       op: add
+      path: "/default_filter_chain/filters/0/typed_config/use_remote_address"
+      value: true
+  - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
+    name: "{{ .Release.Namespace }}/{{ $gatewayName }}/http"
+    operation:
+      op: add
       path: "/default_filter_chain/filters/0/typed_config/preserve_external_request_id"
+      value: true
+  - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
+    name: "{{ .Release.Namespace }}/{{ $gatewayName }}/https"
+    operation:
+      op: add
+      path: "/filter_chains/0/filters/0/typed_config/use_remote_address"
       value: true
   - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
     name: "{{ .Release.Namespace }}/{{ $gatewayName }}/https"

--- a/charts/controlplane/templates/envoy_patch_policy_request_id.yaml
+++ b/charts/controlplane/templates/envoy_patch_policy_request_id.yaml
@@ -1,0 +1,24 @@
+{{- $gatewayName := include "controlplane.fullname" . -}}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyPatchPolicy
+metadata:
+  name: {{ $gatewayName }}-request-id-patch
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ $gatewayName }}
+  type: JSONPatch
+  jsonPatches:
+  - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
+    name: "{{ .Release.Namespace }}/{{ $gatewayName }}/http"
+    operation:
+      op: add
+      path: "/default_filter_chain/filters/0/typed_config/preserve_external_request_id"
+      value: true
+  - type: "type.googleapis.com/envoy.config.listener.v3.Listener"
+    name: "{{ .Release.Namespace }}/{{ $gatewayName }}/https"
+    operation:
+      op: add
+      path: "/filter_chains/0/filters/0/typed_config/preserve_external_request_id"
+      value: true


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adds a envoy patch so that Envoy stops overriding request-id if caller sends its own request id

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/roclub/controlplane/issues/489

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We want to preserve frontend request id if any

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Copilot + KIND: created minicluster that launched an envoy with that patch, and a web server that sent request id, and it got preserved, but still need to test in dev env.