### PR TITLE
chore: bump conference to 0.27.10 fix mute speaker toggle

### DIFF
--- a/charts/roclub-conference/Chart.yaml
+++ b/charts/roclub-conference/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conference
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.27.9
-appVersion: 0.27.9
+version: 0.27.10
+appVersion: 0.27.10


### PR DESCRIPTION
## Description

  Bumps `roclub-conference` chart from `0.27.9` to `0.27.10` to deploy the speaker mute toggle fix (#714).

  **Changes:**
  - `charts/roclub-conference/Chart.yaml`: `version` and `appVersion` bumped to `0.27.10`

## How Has This Been Tested?

helm lint / helm template render cleanly; only the image tag changes.