### PR TITLE
chore: bump conference to 0.27.11

### DIFF
--- a/charts/roclub-conference/Chart.yaml
+++ b/charts/roclub-conference/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conference
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.27.10
-appVersion: 0.27.10
+version: 0.27.11
+appVersion: 0.27.11


### PR DESCRIPTION
## Description

Bumps the `roclub-conference` chart from `0.27.10` to `0.27.11`.

Included in the `livekit-remote-control` `0.27.11` release:

- **fix:** distinguish `controlplane-unreachable` from `missing-permissions` (roclub/livekit-remote-control#733).
- **fix:** make permissions prompt scrollable on small screens (roclub/livekit-remote-control#728).
- **chore:** remove old code (roclub/livekit-remote-control#729).
- **chore:** fix linting error (roclub/livekit-remote-control#739).

## Related Issue

N/A.

## Motivation and Context

Roll out the fixes and cleanup from `livekit-remote-control` `0.27.11`.

## How Has This Been Tested?

- `helm lint charts/roclub-conference` is clean.
