### PR TITLE
chore: bump conference to 0.27.12

### DIFF
--- a/charts/roclub-conference/Chart.yaml
+++ b/charts/roclub-conference/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conference
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.27.11
-appVersion: 0.27.11
+version: 0.27.12
+appVersion: 0.27.12


### PR DESCRIPTION
## Description

Bumps the `conference` chart image tag from `0.27.11` to `0.27.12`.

This release contains five bug fixes from the `livekit-remote-control` app:

- **Speaker mute leaks audio on unmute (roclub/livekit-remote-control#745):** `RoomAudioRenderer` was using `volume={0}` to silence remote tracks, which kept audio delivery running at zero gain. Switching to the `muted` prop stops the server from sending audio at all, so participants who unmute after speaker-off can no longer be heard.
- **Session info modal not scrollable on small screens (roclub/livekit-remote-control#744):** The modal now caps its height at `max-h-[90vh]` and scrolls its body when content overflows. The close button is pinned to the top so it stays reachable while scrolling.
- **Microphone not released on mute (roclub/livekit-remote-control#743):** Added `stopMicTrackOnMute: true` to the room `publishDefaults`. Muting the microphone now also releases the device, turning off the OS/browser "mic in use" indicator.
- **Camera not released on webcam mute (roclub/livekit-remote-control#742):** The haircheck probe stream opened during device initialization was kept alive for the whole session. Stopping its tracks right after init means the camera is properly released when muted, turning off the privacy LED.
- **Overlapping waiting-room polling requests (roclub/livekit-remote-control#740):** Under high network latency the fixed polling interval could fire a new request before the previous one finished. An in-flight guard now serializes polls so at most one request is in flight at a time.

## Related Issue

N/A (dependency bump)

## Motivation and Context

All five fixes address privacy, correctness, or reliability regressions that were blocking the `0.27.12` release. The camera and microphone fixes are privacy-sensitive: users expect that muting a device releases it at the OS level. The speaker fix completes a partial fix from `0.27.11`. The modal and polling fixes address usability issues on small screens and slow networks.

## How Has This Been Tested?

`helm lint` passed on the chart after the tag bump.
