### PR TITLE
chore: bump conference to 0.27.13

### DIFF
--- a/charts/roclub-conference/Chart.yaml
+++ b/charts/roclub-conference/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conference
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.27.12
-appVersion: 0.27.12
+version: 0.27.13
+appVersion: 0.27.13


### PR DESCRIPTION
## Description

Bumps the `conference` chart image tag from `0.27.12` to `0.27.13`.

This release contains two features from the `livekit-remote-control` app:

- **Reconnection overlay on the remote control page (roclub/livekit-remote-control#748):** When the operator connection drops, the room reconnects and the video freezes on the last frame. It used to look like only the mouse and keyboard were stuck. An overlay now dims the video area and tells the user they are offline and that the session is trying to reconnect. It also leaves fullscreen so the message is visible.
- **Speaker and microphone testing in the haircheck (roclub/livekit-remote-control#746):** The user can play a test tone through the selected speaker and see a live microphone level before joining a session.

## Related Issue

N/A (dependency bump)

## Motivation and Context

Both features ship in the `0.27.13` app release, so the chart has to point at the new tag. The reconnection overlay makes the frozen state clear. People used to think the connector was broken and opened tickets. The overlay points them to their own internet connection instead. The haircheck testing lets users confirm their audio devices work before the session starts.

## How Has This Been Tested?

`helm lint` passed on the chart after the tag bump.