### PR TITLE
chore: bump conference to 0.27.14

### DIFF
--- a/charts/roclub-conference/Chart.yaml
+++ b/charts/roclub-conference/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conference
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.27.13
-appVersion: 0.27.13
+version: 0.27.14
+appVersion: 0.27.14


### PR DESCRIPTION
## Description

Bumps the `conference` chart image tag from `0.27.13` to `0.27.14`.

This release contains two changes from the `livekit-remote-control` app:

- **Warn the operator when the connector has no mouse or keyboard (roclub/livekit-remote-control#749):** When the KVM USB cable is disconnected, the back-end reports `mouse_ready` or `keyboard_ready` as `false`. A hook polls `GET /v2/connectors/status/{connectorId}` every 5 seconds while an operator or guest is connected. If the devices are not ready, a warning message and a warning button appear in the control bar. The operator can dismiss the message; clicking the button brings it back. Both disappear once the devices are ready again.
- **Add request ID to API calls (roclub/livekit-remote-control#734):** Each outgoing API request now includes a unique request ID header, which reverts and properly re-applies a previous attempt (#731 and #731 revert). This makes it easier to correlate client requests with server logs.

## Related Issue

N/A (dependency bump)

## Motivation and Context

The connector warning gives operators immediate visibility when the USB cable is loose, which is a common support ticket trigger. The request ID change improves observability by letting support and engineering trace a specific client call through the back-end logs.

## How Has This Been Tested?

`helm lint` passed on the chart after the tag bump.
