### PR TITLE
fix: add `v` prefix to image version

### DIFF
--- a/charts/controlplane-app/Chart.yaml
+++ b/charts/controlplane-app/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: controlplane-app
 description: Deploys the Control Plane App microservice
 type: application
-version: 0.0.4
-appVersion: "1.0.0"
+version: 0.0.5
+appVersion: "v1.0.0"


### PR DESCRIPTION
## Description
add `v` prefix to image version in controlplane-app
