### PR TITLE
fix: model write job image name not correct

### DIFF
--- a/charts/controlplane-authz/Chart.yaml
+++ b/charts/controlplane-authz/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: controlplane-authz
 description: Deploys the AuthZ micro service
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "1.3.0"

--- a/charts/controlplane-authz/templates/authz/provisioning_job.yaml
+++ b/charts/controlplane-authz/templates/authz/provisioning_job.yaml
@@ -26,8 +26,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: openfga-model-writer
-          image: "{{ .Values.provisioning.image.repository }}:{{ .Values.provisioning.image.tag }}"
-          imagePullPolicy: {{ .Values.provisioning.image.pullPolicy }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - model
             - write


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Fixes configuration for image name to be the same like the authz service itself.
<img width="1863" height="93" alt="Screenshot 2026-07-06 at 15 30 44" src="https://github.com/user-attachments/assets/dea71f96-70d6-4991-8a1e-91116ff71946" />

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> Closes #391 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->