### PR TITLE
chore: bump conference to 0.27.15

### DIFF
--- a/charts/roclub-conference/Chart.yaml
+++ b/charts/roclub-conference/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conference
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.27.14
-appVersion: 0.27.14
+version: 0.27.15
+appVersion: 0.27.15


### PR DESCRIPTION
## Description

Bumps the `conference` chart image tag from `0.27.14` to `0.27.15`.

This release contains four bug fixes from the `livekit-remote-control` app:

- **Multi-tab OIDC refresh token collision (roclub/livekit-remote-control#761):** Moved OIDC stores to `sessionStorage` so each tab holds its own refresh token and tabs no longer invalidate each other.
- **No sound on request control popup (roclub/livekit-remote-control#759):** `RequestControlListener` now plays the join-request notification sound when a Guest requests control, matching the waiting room flow.
- **Role escalation on rejoin (roclub/livekit-remote-control#757):** The rejoin-without-reapproval record now stores the approved role; a user returning with a different role goes through the normal approval flow.
- **Re-approval required after involuntary drop (roclub/livekit-remote-control#752):** Approved users who drop due to a connection loss or connector restart are let back in automatically within a two-minute window. A kick or deliberate exit still requires full approval.

## Related Issue

N/A (dependency bump)

## Motivation and Context

The OIDC fix addresses repeated involuntary session drops during long shifts when support opens two tabs in the same browser profile. The rejoin fix removes the friction of re-approving a user after an involuntary drop that was never the operator's intent. The role-check fix closes a privilege escalation that the rejoin feature introduced. The sound fix closes a UX gap where a Guest's control request could be missed by an operator not looking at the screen.

## How Has This Been Tested?

`helm lint` passed on the chart after the tag bump.
