### PR TITLE
chore: bump conference to 0.27.17

### DIFF
--- a/charts/roclub-conference/Chart.yaml
+++ b/charts/roclub-conference/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conference
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.27.16
-appVersion: 0.27.13
+version: 0.27.17
+appVersion: 0.27.17


### PR DESCRIPTION
## Description

Hotfix bump of the `conference` chart from `0.27.13` to `0.27.17`.

This is a targeted hotfix release with a single fix:

- **Remote mouse cursor lands at the wrong position (roclub/livekit-remote-control#763):** `useMouse.ts` was computing the video offset with `offsetLeft`/`offsetTop`, which are measured from the nearest positioned ancestor. A container added by the reconnection overlay in #748 silently became that ancestor, shifting the reference frame and making every click land lower and to the right. Switching to `getBoundingClientRect()` measures from the viewport, the same frame as `clientX`/`clientY`, and the offset is gone.

The four fixes that shipped in `0.27.15` (OIDC token isolation, request control sound, role check on rejoin, and rejoin without re-approval) are not included here since they were never deployed to production. They remain on `main` and will ship in the next regular release.

## Related Issue

N/A (dependency bump)

## Motivation and Context

The bug broke remote mouse control for all operators on the current production build. The hotfix is scoped to the one file that changed (`src/hooks/useMouse.ts`) so the blast radius is minimal.

## How Has This Been Tested?

`helm lint` passed on the chart after the tag bump.
