### PR TITLE
feat(charts): add zitadel project ID config

### DIFF
--- a/charts/controlplane-app/Chart.yaml
+++ b/charts/controlplane-app/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: controlplane-app
 description: Deploys the Control Plane App microservice
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v1.1.0"

--- a/charts/controlplane-app/templates/app/config.yaml
+++ b/charts/controlplane-app/templates/app/config.yaml
@@ -23,6 +23,8 @@ data:
         apiKey: {{ .Values.config.calCom.apiKey | quote }}
         apiVersion: {{ .Values.config.calCom.apiVersion | quote }}
         baseURL: {{ .Values.config.calCom.baseUrl | quote }}
+      zitadel:
+        projectID: {{ .Values.config.zitadel.projectID | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/controlplane-app/values.yaml
+++ b/charts/controlplane-app/values.yaml
@@ -40,6 +40,9 @@ config:
     apiVersion: "2024-08-13"
     # config.calCom.baseUrl is the Cal.com API base URL.
     baseUrl: "https://api.cal.eu/v2"
+  zitadel:
+    # config.zitadel.projectID is the Zitadel project ID used for MultiOrg in JWTs.
+    projectID: ""
 
 # service configures the application Service.
 service:


### PR DESCRIPTION
## Background

Closes: #80
Implementation: https://github.com/roclub/controlplane-app/pull/94

## Why is this change needed?

The app needs a Zitadel project ID in chart values and rendered config so JWT MultiOrg setup can be configured per deployment.

## Summary

Adds `config.zitadel.projectID` to the chart defaults and wires it into the generated app ConfigMap. Bumps the chart version to `0.1.2`.

## Test Plan

Not run (chart-only change).
