### PR TITLE
chore: bump conference to 0.27.18

### DIFF
--- a/charts/roclub-conference/Chart.yaml
+++ b/charts/roclub-conference/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: conference
 description: Deploys the roclub conference using livekit
 type: application
-version: 0.27.17
-appVersion: 0.27.17
+version: 0.27.18
+appVersion: 0.27.18


### PR DESCRIPTION
## Description

Bumps the `conference` chart image tag from `0.27.17` to `0.27.18`.

The `0.27.17` hotfix was squash-merged, which carried the reverts from the hotfix branch into `main` and silently removed four fixes that had already been reviewed and merged. `0.27.18` restores them as cherry-picks with no other changes. The code is otherwise identical to `0.27.15`.

Restored fixes (roclub/livekit-remote-control#764):

- **Multi-tab OIDC refresh token collision (roclub/livekit-remote-control#761):** Moved OIDC stores to `sessionStorage` so each tab holds its own refresh token and tabs no longer invalidate each other.
- **No sound on request control popup (roclub/livekit-remote-control#759):** `RequestControlListener` now plays the join-request notification sound when a Guest requests control, matching the waiting room flow.
- **Role escalation on rejoin (roclub/livekit-remote-control#757):** The rejoin-without-reapproval record now stores the approved role; a user returning with a different role goes through the normal approval flow.
- **Re-approval required after involuntary drop (roclub/livekit-remote-control#752):** Approved users who drop due to a connection loss or connector restart are let back in automatically within a two-minute window. A kick or deliberate exit still requires full approval.

## Related Issue

N/A (dependency bump)

## Motivation and Context

Since `0.27.17`, the OIDC token isolation fix has been missing. Operators who open the app in two tabs risk being logged out mid-session when Zitadel rotates the shared refresh token.

## How Has This Been Tested?

`helm lint` passed on the chart after the tag bump.