### PR TITLE
fix: add instance discriminator to SecurityPolicy selectors

### DIFF
--- a/charts/controlplane-app/Chart.yaml
+++ b/charts/controlplane-app/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: controlplane-app
 description: Deploys the Control Plane App microservice
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "v1.1.0"

--- a/charts/controlplane-app/templates/app/route.yaml
+++ b/charts/controlplane-app/templates/app/route.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "controlplane-app.labels" . | nindent 4 }}
     authentication/zitadel: jwt
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/charts/controlplane-app/templates/app/security_policy.yaml
+++ b/charts/controlplane-app/templates/app/security_policy.yaml
@@ -12,6 +12,7 @@ spec:
     kind: HTTPRoute
     matchLabels:
       authentication/zitadel: jwt
+      app.kubernetes.io/instance: {{ .Release.Name }}
   jwt:
     providers:
     - name: zitadel

--- a/charts/controlplane-authz/Chart.yaml
+++ b/charts/controlplane-authz/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: controlplane-authz
 description: Deploys the AuthZ micro service
 type: application
-version: 0.5.5
+version: 0.5.6
 appVersion: "1.5.2"

--- a/charts/controlplane-authz/templates/authz/route.yaml
+++ b/charts/controlplane-authz/templates/authz/route.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ $name}}
   labels:
     authentication/zitadel: jwt
+    app.kubernetes.io/instance: {{ .Release.Name }}
   {{- with .Values.routeAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/controlplane-authz/templates/security_policy.yaml
+++ b/charts/controlplane-authz/templates/security_policy.yaml
@@ -13,6 +13,7 @@ spec:
     kind: HTTPRoute
     matchLabels:
       authentication/zitadel: jwt
+      app.kubernetes.io/instance: {{ .Release.Name }}
   jwt:
     providers:
     - name: zitadel

--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.35.1
+version: 2.35.2
 appVersion: "2.25.0"
 dependencies:
 - name: influxdb2

--- a/charts/controlplane/templates/connector-control/route.yaml
+++ b/charts/controlplane/templates/connector-control/route.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ $gatewayName }}-connector-control
   labels:
     authentication/zitadel: jwt
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/charts/controlplane/templates/connector-status/route.yaml
+++ b/charts/controlplane/templates/connector-status/route.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ $gatewayName }}-connector-status
   labels:
     authentication/zitadel: jwt
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/charts/controlplane/templates/notifications/route.yaml
+++ b/charts/controlplane/templates/notifications/route.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ $gatewayName }}-notifications
   labels:
     authentication/zitadel: jwt
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/charts/controlplane/templates/remote-control/route.yaml
+++ b/charts/controlplane/templates/remote-control/route.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ $gatewayName }}-remote-control
   labels:
     authentication/zitadel: jwt
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/charts/controlplane/templates/security_policy.yaml
+++ b/charts/controlplane/templates/security_policy.yaml
@@ -9,6 +9,7 @@ spec:
     kind: HTTPRoute
     matchLabels:
       authentication/zitadel: jwt
+      app.kubernetes.io/instance: {{ .Release.Name }}
   jwt:
     providers:
     - name: zitadel


### PR DESCRIPTION
- Add app.kubernetes.io/instance label to all HTTPRoute templates
- Update SecurityPolicy matchLabels to include instance discriminator
- Prevents conflicts when multiple charts target same authentication/zitadel routes
- Bump chart versions: controlplane 2.35.1→2.35.2, controlplane-authz 0.5.5→0.5.6, controlplane-app 0.1.3→0.1.4

