### PR TITLE
chore(chart): bump controlplane-app to 0.1.8

### DIFF
--- a/charts/controlplane-app/Chart.yaml
+++ b/charts/controlplane-app/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: controlplane-app
 description: Deploys the Control Plane App microservice
 type: application
-version: 0.1.7
-appVersion: "v1.1.0"
+version: 0.1.8
+appVersion: "v1.2.0"


### PR DESCRIPTION
## Background

## Why is this change needed?

Keep the chart metadata aligned with the released app version.

## Summary

Bump `charts/controlplane-app/Chart.yaml` to version `0.1.8` and `appVersion` to `v1.2.0`.

## Test Plan

Not run.
