### PR TITLE
feat(controlplane): session-usage InfluxDB bucket and remote-control wiring

### DIFF
--- a/charts/controlplane/Chart.yaml
+++ b/charts/controlplane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: controlplane
 description: Deploys all microservices associated with managing and controlling the roclub connectors
 type: application
-version: 2.37.0
+version: 2.38.0
 appVersion: "2.23.1"
 dependencies:
 - name: influxdb2

--- a/charts/controlplane/templates/remote-control/config.yaml
+++ b/charts/controlplane/templates/remote-control/config.yaml
@@ -1,3 +1,4 @@
+{{- $influxName := include "controlplane.fullname" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -45,3 +46,7 @@ data:
 
     [session_control.notification_service]
     address = "http://{{ include "controlplane.notificationsName" . }}:8080"
+
+    [session_control.session_usage_repository]
+    influxdb_org = "{{ .Values.remoteControl.config.influx.org }}"
+    influxdb_url = "http://{{ $influxName }}-influxdb2"

--- a/charts/controlplane/templates/remote-control/deployment.yaml
+++ b/charts/controlplane/templates/remote-control/deployment.yaml
@@ -69,6 +69,12 @@ spec:
           - name: controlplane-redis-client-tls
             mountPath: /etc/redis/tls
             readOnly: true
+          env:
+          - name: INFLUXDB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "controlplane.fullname" . }}-influxdb2-auth
+                key: admin-token
       volumes:
         - name: config-volume
           configMap:

--- a/charts/controlplane/values.yaml
+++ b/charts/controlplane/values.yaml
@@ -107,6 +107,9 @@ remoteControl:
       host: ""
       ttl: 300
 
+    influx:
+      org: "roclub"
+
     logger: "debug"
 
   service:
@@ -296,6 +299,27 @@ influxdb2:
     bucket: "connector-status"
     user: "admin"
     retention_policy: "0s"
+
+  initScripts:
+    enabled: true
+    scripts:
+      init.sh: |+
+        #!/bin/sh
+        set -eu
+
+        export INFLUX_HOST="http://localhost:8086"
+        BUCKET_NAME="session-usage"
+
+        if influx bucket list --org "$DOCKER_INFLUXDB_INIT_ORG" --token "$DOCKER_INFLUXDB_INIT_ADMIN_TOKEN" --name "$BUCKET_NAME" --json | grep -q '"name":"'"$BUCKET_NAME"'"'; then
+          echo "bucket $BUCKET_NAME already exists"
+          exit 0
+        fi
+
+        influx bucket create \
+          --org "$DOCKER_INFLUXDB_INIT_ORG" \
+          --token "$DOCKER_INFLUXDB_INIT_ADMIN_TOKEN" \
+          --name "$BUCKET_NAME" \
+          --retention 0s
 
   persistence:
     enabled: false


### PR DESCRIPTION
## Summary

Helm chart changes to support session usage tracking storage (related to https://github.com/roclub/controlplane/issues/536).

## Changes

- **influxdb2 initScripts**: Creates the `session-usage` bucket idempotently on InfluxDB startup
- **remote-control deployment**: Injects `INFLUXDB_TOKEN` env var from the `influxdb2-auth` secret
- **remote-control config**: Adds `[session_control.session_usage_repository]` section with `influxdb_org` and `influxdb_url`
- **values.yaml**: Adds `remoteControl.config.influx.org` default (`roclub`) to match connector-status pattern