### PR TITLE
feat: wait for redis

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: app
 description: Deploys the roclub main application to Kubernetes
 type: application
-version: 0.19.1
+version: 0.19.2
 appVersion: 0.19.1
 
 dependencies:

--- a/charts/app/templates/deployment.yaml
+++ b/charts/app/templates/deployment.yaml
@@ -29,6 +29,45 @@ spec:
       - name: redis-server-tls
         secret:
           secretName: redis-server-tls
+      - name: redis-password
+        secret:
+          secretName: {{ .Release.Name }}-redis
+          items:
+            - key: redis-password
+              path: redis-password
+      {{- if .Values.redisWait.enabled }}
+      initContainers:
+        - name: wait-for-redis
+          image: "{{ .Values.redisWait.image.repository }}:{{ .Values.redisWait.image.tag }}"
+          imagePullPolicy: {{ .Values.redisWait.image.pullPolicy }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              REDIS_HOST="{{ .Release.Name }}-redis-headless"
+              export REDISCLI_AUTH="$(cat /opt/bitnami/redis/secrets/redis-password)"
+
+              until getent hosts "${REDIS_HOST}"; do
+                echo "waiting for Redis DNS: ${REDIS_HOST}"
+                sleep 2
+              done
+
+              until redis-cli --tls \
+                --cacert /opt/bitnami/redis/certs/ca.crt \
+                -h "${REDIS_HOST}" \
+                -p 6379 \
+                ping; do
+                echo "waiting for Redis: ${REDIS_HOST}:6379"
+                sleep 2
+              done
+          volumeMounts:
+            - name: redis-server-tls
+              readOnly: true
+              mountPath: /opt/bitnami/redis/certs
+            - name: redis-password
+              readOnly: true
+              mountPath: /opt/bitnami/redis/secrets
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -96,6 +96,13 @@ service:
   type: ClusterIP
   port: 8080
 
+redisWait:
+  enabled: true
+  image:
+    repository: registry-1.docker.io/bitnami/redis
+    tag: latest
+    pullPolicy: IfNotPresent
+
 redis:
   auth:
     enabled: true


### PR DESCRIPTION
## Description
Adds an app initContainer that waits for Redis before starting the main app container.

On stg, the app and Redis resources were created at nearly the same time. The logs show the app started trying to connect before Redis DNS and Redis itself were fully available.

---

Observed timeline:

2026-07-29T08:30:39Z
Service/stg-redis-headless created

2026-07-29T08:30:43Z
app: getaddrinfo ENOTFOUND stg-redis-headless

2026-07-29T08:30:44Z
app: getaddrinfo ENOTFOUND stg-redis-headless

2026-07-29T08:30:45Z
app: getaddrinfo ENOTFOUND stg-redis-headless

2026-07-29T08:30:46Z
app: getaddrinfo ENOTFOUND stg-redis-headless

2026-07-29T08:30:49Z
app: connect ECONNREFUSED 10.10.4.225:6379

2026-07-29T08:30:54Z
app: connect ECONNREFUSED 10.10.4.225:6379

2026-07-29T08:30:55Z
redis: Ready to accept connections tls

This suggests two startup windows:

ENOTFOUND: Service DNS was not visible to the app yet
ECONNREFUSED: DNS was visible, but Redis was not accepting connections yet

---

The app Deployment now includes wait-for-redis as an initContainer. It waits until Redis is reachable.

## Related Issue
https://github.com/roclub/app/issues/793
