### PR TITLE
fix: adjust OpenFGA model

### DIFF
--- a/charts/controlplane-authz/Chart.yaml
+++ b/charts/controlplane-authz/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: controlplane-authz
 description: Deploys the AuthZ micro service
 type: application
-version: 0.5.8
+version: 0.5.9
 appVersion: "1.5.4"

--- a/charts/controlplane-authz/values.yaml
+++ b/charts/controlplane-authz/values.yaml
@@ -103,12 +103,13 @@ provisioning:
         define parent: [platform]
         define member: [user]
         define admin: [user] or csm from parent
+        define csm: csm from parent
 
     type connector
       relations
         define parent: [organization]
-        define local_operator: [user] or admin from parent
-        define remote_operator: [user] or admin from parent
+        define local_operator: [user] or csm from parent
+        define remote_operator: [user] or csm from parent
         define guest: [user]
         define admin: admin from parent
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Fixes unintentional passing down of permissions. Instead of using `admin from parent` (that includes actual organization admins & csm's), we now added a new `csm` relation that allows us to use `csm from parent` in our connector type. This way, organizations admins required again explict permissions to connectors

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: --> Closes #587 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->