### PR TITLE
chore(controlplane-app): align chart config with backend schema

### DIFF
--- a/charts/controlplane-app/Chart.yaml
+++ b/charts/controlplane-app/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: controlplane-app
 description: Deploys the Control Plane App microservice
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: "v1.2.0"

--- a/charts/controlplane-app/templates/app/config.yaml
+++ b/charts/controlplane-app/templates/app/config.yaml
@@ -22,9 +22,15 @@ data:
       calCom:
         apiKey: {{ .Values.config.calCom.apiKey | quote }}
         apiVersion: {{ .Values.config.calCom.apiVersion | quote }}
-        baseURL: {{ .Values.config.calCom.baseUrl | quote }}
+        baseURL: {{ .Values.config.calCom.baseURL | quote }}
       zitadel:
-        projectID: {{ .Values.config.zitadel.projectID | quote }}
+        coreAppProjectID: {{ .Values.config.zitadel.coreAppProjectID | quote }}
+        knowledgebaseProjectID: {{ .Values.config.zitadel.knowledgebaseProjectID | quote }}
+        conferenceProjectID: {{ .Values.config.zitadel.conferenceProjectID | quote }}
+        instanceURL: {{ .Values.config.zitadel.instanceURL | quote }}
+        serviceAccountKey: {{ .Values.config.zitadel.serviceAccountKey | quote }}
+      controlPlaneAuthz:
+        address: {{ .Values.config.controlPlaneAuthz.address | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/controlplane-app/values.yaml
+++ b/charts/controlplane-app/values.yaml
@@ -38,11 +38,22 @@ config:
     apiKey: ""
     # config.calCom.apiVersion is the requested Cal.com API version.
     apiVersion: "2024-08-13"
-    # config.calCom.baseUrl is the Cal.com API base URL.
-    baseUrl: "https://api.cal.eu/v2"
+    # config.calCom.baseURL is the Cal.com API base URL.
+    baseURL: "https://api.cal.eu/v2"
   zitadel:
-    # config.zitadel.projectID is the Zitadel project ID used for MultiOrg in JWTs.
-    projectID: ""
+    # config.zitadel.coreAppProjectID is the main Zitadel project ID used for MultiOrg in JWTs.
+    coreAppProjectID: ""
+    # config.zitadel.knowledgebaseProjectID is the knowledge base Zitadel project ID.
+    knowledgebaseProjectID: ""
+    # config.zitadel.conferenceProjectID is the conference Zitadel project ID.
+    conferenceProjectID: ""
+    # config.zitadel.instanceURL is the Zitadel instance base URL.
+    instanceURL: ""
+    # config.zitadel.serviceAccountKey is the Zitadel service account credential.
+    serviceAccountKey: ""
+  controlPlaneAuthz:
+    # config.controlPlaneAuthz.address is the control plane authz service address.
+    address: ""
 
 # service configures the application Service.
 service:


### PR DESCRIPTION
## Background

Related: #81

## Why is this change needed?

Keep the Helm chart config in sync with the backend schema so the release can pass the updated Zitadel and authz settings through.

## Summary

- update `config.yaml` template keys to match the new backend config shape
- add the new Zitadel and control plane authz values
- bump chart version to `0.1.13`

## Test Plan

- `helm template controlplane-app charts/controlplane-app`
